### PR TITLE
fix: update background colors in theme files for higher contrast (#1)

### DIFF
--- a/dist/rose-pine-moon.kdl
+++ b/dist/rose-pine-moon.kdl
@@ -1,6 +1,6 @@
 themes {
 	rose-pine-moon {
-		bg "#232136"
+		bg "#44415a"
 		fg "#e0def4"
 		red "#eb6f92"
 		green "#3e8fb0"

--- a/dist/rose-pine.kdl
+++ b/dist/rose-pine.kdl
@@ -1,6 +1,6 @@
 themes {
 	rose-pine {
-		bg "#191724"
+		bg "#403d52"
 		fg "#e0def4"
 		red "#eb6f92"
 		green "#31748f"


### PR DESCRIPTION
### Justification

Current scheme blends selected text with background. Proposed PR improves contrast for text selection in the darker Rosé Pine themes for Zellij utilising a brighter color from the standard palettes.

Fixes #1 

### Changes

- Swapped bg value to use the value from Highlight Med for Rosé Pine and Rosé Pine Moon themes

