### PR TITLE
fix: zellij `bg` is `selection background`

### DIFF
--- a/dist/rose-pine-dawn.kdl
+++ b/dist/rose-pine-dawn.kdl
@@ -1,6 +1,6 @@
 themes {
 	rose-pine-dawn {
-		bg "#faf4ed"
+		bg "#dfdad9"
 		fg "#575279"
 		red "#b4637a"
 		green "#286983"

--- a/template.kdl
+++ b/template.kdl
@@ -1,6 +1,6 @@
 themes {
 	$id {
-		bg "$base"
+		bg "$highlightMed"
 		fg "$text"
 		red "$love"
 		green "$pine"


### PR DESCRIPTION
highlight med should be used.

Someone did this manually for the dark themes: https://github.com/rose-pine/zellij/commit/9f7fd716df42f4556fc4b2fceae98ead9bc841e6

The light variant needs the same change. With this everything matches the template again.
